### PR TITLE
修正蓝奏失效域名

### DIFF
--- a/docs/faq/slider.md
+++ b/docs/faq/slider.md
@@ -57,7 +57,7 @@
 
 此方案需要您有一台可以操作的 `Windows` 电脑。
 
-首先下载工具:  [蓝奏云](https://wws.lanzous.com/i2vn0jrofte) [Google Drive](https://drive.google.com/file/d/1peMDHqgP8AgWBVp5vP-cfhcGrb2ksSrE/view?usp=sharing)
+首先下载工具:  [蓝奏云](https://wws.lanzoui.com/i2vn0jrofte) [Google Drive](https://drive.google.com/file/d/1peMDHqgP8AgWBVp5vP-cfhcGrb2ksSrE/view?usp=sharing)
 
 解压并打开工具: 
 


### PR DESCRIPTION
蓝奏此前发过短信通知, `lanzous.com` 域名已不可用, 无法访问
目前的解决方法是, 将文件链接 `https://xxx.lanzous.com/*` 中的 `s` 换成 `i` 或者 `x`
此次简单修改, 目的为了确保链接能正常访问