### PR TITLE
在文档/get_forward_msg中可能产生歧义的字段添加提示

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -121,6 +121,8 @@
 | ------------ | ------ | ------ |
 | `message_id` | string | 消息id |
 
+::: tip 提示 此处的`message_id`对应[合并转发](https://docs.go-cqhttp.org/cqcode/#%E5%90%88%E5%B9%B6%E8%BD%AC%E5%8F%91)中的`id`字段 :::
+
 **响应数据**
 
 | 字段       | 类型              | 说明     |


### PR DESCRIPTION
一开始以为是合并转发的那个消息的id, 发现是string, 就验证了一下, 
私下认为添加一个tips会比较妥当。