### PR TITLE
📝 Remove `Home` navbar item

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -59,7 +59,6 @@ export default defineUserConfig<DefaultThemeOptions>({
         danger: "警告",
         backToHome: "返回首页",
         navbar: [
-            { text: 'Home', link: '/' },
             { text: 'Guide', children: ['/guide/', '/guide/quick_start.md', '/guide/config.md', '/guide/eventfilter.md', '/guide/file.md', '/guide/achieve.md'] },
             { text: 'API', children: ['/api/', '/api/guild.md'] },
             { text: 'Event', children: ['/event/', '/event/guild.md'] },


### PR DESCRIPTION
变更理由：

- 点击左上角文字 LOGO 可以便捷地返回主页
- 利于中屏设备正常显示（当前对于中屏设备，存在部分 Item Overflow Screen）