### PR TITLE
fix : add message_type to MessageEvent

### DIFF
--- a/docs/event/README.md
+++ b/docs/event/README.md
@@ -26,7 +26,8 @@ post_type 为 message 的上报将会有以下有效通用数据
 
 | 字段名 | 数据类型 | 可能的值 | 说明 |
 |-------------|--------------------------------------------------------|------|----|
-| sub_type  | string [参考](Post_Message_SubType) | group, public | 表示消息的子类型 |
+| message_type | string [参考](/reference/data_struct/#Post_Message_Type) | private, group | 消息类型 |
+| sub_type  | string [参考](/reference/data_struct/#Post_Message_SubType) | group, public | 表示消息的子类型 |
 | message_id  | int32  | - | 消息 ID |
 | user_id | int64  | - | 发送者 QQ 号 |
 | message | message  | - | 一个消息链 |

--- a/docs/reference/data_struct.md
+++ b/docs/reference/data_struct.md
@@ -43,6 +43,14 @@
 
 > 该消息在 "message" 上报中被使用
 
+## Post_Message_Type
+
+一个枚举, 传输使用字符串, 表示消息类型.
+
+| 值 | 说明 |
+| ------- | -------- |
+| private | 私聊消息 |
+| group   | 群消息 |
 
 ## Post_Message_SubType
 


### PR DESCRIPTION
## Description
文档中Message定义缺少message_type。同时sub_type指向的位置有错误(404)
![image](https://user-images.githubusercontent.com/69711608/203490189-49313675-e4eb-40b6-8191-18181ee9b928.png)
![image](https://user-images.githubusercontent.com/69711608/203490454-1e9cd899-def4-4e2b-a82c-7406858099b9.png)
