### PR TITLE
fix: parameter of `/delete_friend`

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -622,7 +622,7 @@ retcode 字段:
 
 | 字段名 | 数据类型 | 默认值 | 说明 |
 | ----- | ------- | ----- | --- |
-| `friend_id` | int64 | - | 好友 QQ 号 |
+| `user_id` | int64 | - | 好友 QQ 号 |
 
 ::: tip 提示
 该 API 无响应数据
@@ -1619,7 +1619,7 @@ JSON数组:
 :::
 
 
-### 删除单项好友
+### 删除单向好友
 
 终结点：`/delete_unidirectional_friend`
 


### PR DESCRIPTION
1. 删除好友的参数有误，见 https://github.com/Mrs4s/go-cqhttp/issues/1632
2. 修复错别字