### PR TITLE
纠正 docs/reference/readme.md 中 :79 与 :84 的 Access Token 不一致的问题

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -76,7 +76,7 @@ GET /api HTTP/1.1
 Authorization: Bearer access-token
 ```
 
-例如, 当你在配置文件中指定 Access token 为 "1114514" 的时候, 那么任何通过 HTTP 和正向 WebSocket 连接到 go-cqhttp 的请求都需要添加这个头
+例如, 当你在配置文件中指定 Access token 为 "114514" 的时候, 那么任何通过 HTTP 和正向 WebSocket 连接到 go-cqhttp 的请求都需要添加这个头
 
 ```http
 GET /api HTTP/1.1


### PR DESCRIPTION
文件 docs/reference/readme.md 中第79行和第84行中的 Access Token 不一致，此拉取请求纠正了这个问题。